### PR TITLE
Compatible with Meteor 0.9.x

### DIFF
--- a/server.js
+++ b/server.js
@@ -2,12 +2,11 @@ AngularStack = {
   module: null,
   attribHook: function (request) {
     if (AngularStack.module === null) 
-	  return 'ng-app';
-	  
-    if (AngularStack.module === false) 
-	  return '';
-	
-	return 'ng-app="' + AngularStack.module + '"';
+        return {'ng-app': ''};
+    else if (AngularStack.module === false) 
+        return {};
+    else
+	return {'ng-app': AngularStack.module};
   }
 };
 WebApp.addHtmlAttributeHook(AngularStack.attribHook);


### PR DESCRIPTION
input to WebApp.adHtmlAttributeHook is an object now instead of a string
